### PR TITLE
Critical bugfix

### DIFF
--- a/lib/ring.ml
+++ b/lib/ring.ml
@@ -180,7 +180,23 @@ module Front = struct
     done;
     if check_for_responses t then ack_responses t fn
 
-end
+  let to_string t =
+    let nr_unconsumed_responses = (sring_rsp_prod t.sring) - t.rsp_cons in
+    let nr_free_requests = get_free_requests t in
+    Printf.sprintf "Front { req_prod = %d; rsp_prod = %d; req_event = %d; rsp_event = %d; rsp_cons = %d; req_prod_pvt = %d; %s; %s }"
+      (sring_req_prod t.sring)
+      (sring_rsp_prod t.sring)
+      (sring_req_event t.sring)
+      (sring_rsp_event t.sring)
+      t.rsp_cons
+      t.req_prod_pvt
+      (if nr_unconsumed_responses > 0
+       then Printf.sprintf "%d unconsumed responses" nr_unconsumed_responses
+       else "frontend has consumed all responses")
+      (if nr_free_requests > 0
+       then Printf.sprintf "%d free request slots" nr_free_requests
+       else "all slots are full")
+    end
 
 module Back = struct
 

--- a/lib/ring.mli
+++ b/lib/ring.mli
@@ -81,6 +81,9 @@ module Front : sig
   (** [push_requests_and_check_notify frontend] updates the shared
       request producer, and returns [true] if an event notification is
       required to wake up the remote domain. *)
+
+  val to_string : ('a, 'b) t -> string
+  (** [to_string t] pretty-prints ring metadata *)
 end
 
 (** The back-end of the shared ring, which reads requests and writes

--- a/lwt/lwt_ring.ml
+++ b/lwt/lwt_ring.ml
@@ -95,6 +95,7 @@ module Front = struct
        | Some u -> Lwt.wakeup_exn u Shutdown; loop ()
      in loop ()
 
+  let to_string t = Ring.Rpc.Front.to_string t.ring
 end
 
 module Back = struct

--- a/lwt/lwt_ring.mli
+++ b/lwt/lwt_ring.mli
@@ -60,6 +60,10 @@ module Front : sig
       signal. *)
 
   val shutdown : ('a, 'b) t -> unit
+
+  val to_string : ('a,'b) t -> string
+  (** [to_string t] returns debug-printable description of the ring
+      metadata *)
 end
 
 (** The (server) back-end connection to the shared ring. *)


### PR DESCRIPTION
The ring wasn't being properly initialised and the event counters were 0 rather than 1. This would prevent the backend signalling the frontend. Possibly the shared event channel for networking masked this?
