### PR TITLE
Don't link PPX rewriters into clients

### DIFF
--- a/lib/jbuild
+++ b/lib/jbuild
@@ -2,7 +2,7 @@
  ((name        shared_memory_ring)
   (public_name shared-memory-ring)
   (c_names     (barrier_stubs))
-  (libraries   (cstruct cstruct.ppx))
+  (libraries   (cstruct))
   (wrapped     false)
   (preprocess (pps (cstruct.ppx)))
 ))


### PR DESCRIPTION
The package cstruct.ppx contains helper functions for the PPX rewriter itself. Linking this code into applications makes them larger and also brings in a dependency on compiler-libs which pollutes the global module namespace with names like Types.

See mirage/mirage-www#556

Signed-off-by: David Scott <dave@recoil.org>