### PR TITLE
Use `bytes` rather than `string` for mutation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
 language: c
-install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
-script: bash -ex .travis-opam.sh
+sudo: false
+services:
+  - docker
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-docker.sh
+script: bash ./.travis-docker.sh
 env:
-  - PACKAGE="shared-memory-ring-lwt" OCAML_VERSION=4.03 REVDEPS=true
-  - PACKAGE="shared-memory-ring-lwt" OCAML_VERSION=4.02 REVDEPS=true
-  - PACKAGE="shared-memory-ring-lwt" OCAML_VERSION=4.06
+ global:
+   - PINS="shared-memory-ring:. shared-memory-ring-lwt:."
+ matrix:
+   - DISTRO=alpine OCAML_VERSION=4.04.0 PACKAGE="shared-memory-ring"
+   - DISTRO=alpine OCAML_VERSION=4.04.0 PACKAGE="shared-memory-ring-lwt"
+   - DISTRO=alpine OCAML_VERSION=4.06.0 PACKAGE="shared-memory-ring"
+   - DISTRO=alpine OCAML_VERSION=4.06.0 PACKAGE="shared-memory-ring-lwt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ script: bash -ex .travis-opam.sh
 env:
   - PACKAGE="shared-memory-ring-lwt" OCAML_VERSION=4.03 REVDEPS=true
   - PACKAGE="shared-memory-ring-lwt" OCAML_VERSION=4.02 REVDEPS=true
+  - PACKAGE="shared-memory-ring-lwt" OCAML_VERSION=4.06

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## 3.0.0 (2017-11-05)
+
+* Update to use `bytes` in the `read` call, to work with OCaml 4.06 and
+  `-safe-string`
+
 ## 2.0.1 (2017-06-07)
 * Don't force clients to link against `cstruct.ppx`: this is the support code
   for the PPX rewriter itself, and brings in the `compiler-libs` package etc.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 ## 3.0.0 (2017-11-05)
 
-* Update to use `bytes` in the `read` call, to work with OCaml 4.06 and
+* Update to use `bytes` in the `read` and `write`, to work with OCaml 4.06 and
   `-safe-string`
 
 ## 2.0.1 (2017-06-07)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,20 @@
 platform:
-  - x86
+  - x64
 
 environment:
-  CYG_ROOT: "C:\\cygwin"
+  CYG_ROOT: "C:\\cygwin64"
+  CYG_CACHE: C:/cygwin64/var/cache/setup
+  CYG_MIRROR: http://mirrors.kernel.org/sourceware/cygwin/
+  CYG_ARCH: x86_64
   CYG_BASH: "%CYG_ROOT%\\bin\\bash -lc"
+  CYGWIN: "winsymlinks:native"
   PACKAGE: "shared-memory-ring-lwt"
 
 install:
+  - 'appveyor DownloadFile http://cygwin.com/setup-%CYG_ARCH%.exe -FileName setup.exe'
+  - 'setup.exe -gqnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P make,git,rsync,perl,gcc-core,gcc-g++,libncurses-devel,unzip,libmpfr-devel,patch,flexdll,libglpk-devel'
   - appveyor DownloadFile https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/appveyor-opam.sh
-  - "%CYG_ROOT%\\setup-x86.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P rsync -P patch -P make -P git -P perl -P mingw64-x86_64-gcc-core"
-  - curl -L -o C:/cygwin/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-win32.exe
+  - curl -L -o C:/cygwin64/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-win32.exe
 
 build_script:
   - "%CYG_BASH% '${APPVEYOR_BUILD_FOLDER}/appveyor-opam.sh'"

--- a/lib/ring.ml
+++ b/lib/ring.ml
@@ -330,10 +330,10 @@ module type S = sig
   module Writer: WRITABLE
 
   val write: Cstruct.t -> string -> int -> int -> int
-  val read: Cstruct.t -> string -> int -> int -> int
+  val read: Cstruct.t -> bytes -> int -> int -> int
 
   val unsafe_write: Cstruct.t -> string -> int -> int -> int
-  val unsafe_read: Cstruct.t -> string -> int -> int -> int
+  val unsafe_read: Cstruct.t -> bytes -> int -> int -> int
 end
 
 
@@ -406,7 +406,7 @@ module Pipe(RW: RW) = struct
     let seq, frag = Reader.read t in
     let data_available = Cstruct.len frag in
     let can_read = min len data_available in
-    Cstruct.blit_to_string frag 0 buf ofs can_read;
+    Cstruct.blit_to_bytes frag 0 buf ofs can_read;
     Reader.advance t Int32.(add seq (of_int can_read));
     can_read
 

--- a/lib/ring.ml
+++ b/lib/ring.ml
@@ -329,10 +329,10 @@ module type S = sig
   module Reader: READABLE
   module Writer: WRITABLE
 
-  val write: Cstruct.t -> string -> int -> int -> int
+  val write: Cstruct.t -> bytes -> int -> int -> int
   val read: Cstruct.t -> bytes -> int -> int -> int
 
-  val unsafe_write: Cstruct.t -> string -> int -> int -> int
+  val unsafe_write: Cstruct.t -> bytes -> int -> int -> int
   val unsafe_read: Cstruct.t -> bytes -> int -> int -> int
 end
 
@@ -414,7 +414,7 @@ module Pipe(RW: RW) = struct
     let seq, frag = Writer.write t in
     let free_space = Cstruct.len frag in
     let can_write = min len free_space in
-    Cstruct.blit_from_string buf ofs frag 0 can_write;
+    Cstruct.blit_from_bytes buf ofs frag 0 can_write;
     Writer.advance t Int32.(add seq (of_int can_write));
     can_write
 

--- a/lib/ring.mli
+++ b/lib/ring.mli
@@ -199,7 +199,7 @@ module type S = sig
      If you do need to reconnect or need to avoid copying, use the READER and
      WRITABLE signatures above *)
 
-  val write: Cstruct.t -> string -> int -> int -> int
+  val write: Cstruct.t -> bytes -> int -> int -> int
   (** [write stream buf ofs len] writes up to [len] bytes from [buf] at [ofs]
       to [stream]. If this returns short it means EOF *)
 
@@ -208,7 +208,7 @@ module type S = sig
       [stream]. If this returns short it means EOF *)
 
   (* These functions are deprecated (and nolonger unsafe, see #10) *)
-  val unsafe_write: Cstruct.t -> string -> int -> int -> int
+  val unsafe_write: Cstruct.t -> bytes -> int -> int -> int
   val unsafe_read: Cstruct.t -> bytes -> int -> int -> int
 end
 

--- a/lib/ring.mli
+++ b/lib/ring.mli
@@ -203,13 +203,13 @@ module type S = sig
   (** [write stream buf ofs len] writes up to [len] bytes from [buf] at [ofs]
       to [stream]. If this returns short it means EOF *)
 
-  val read: Cstruct.t -> string -> int -> int -> int
+  val read: Cstruct.t -> bytes -> int -> int -> int
   (** [read stream buf ofs len] reads up to [len] bytes to [buf] at [ofs] from
       [stream]. If this returns short it means EOF *)
 
   (* These functions are deprecated (and nolonger unsafe, see #10) *)
   val unsafe_write: Cstruct.t -> string -> int -> int -> int
-  val unsafe_read: Cstruct.t -> string -> int -> int -> int
+  val unsafe_read: Cstruct.t -> bytes -> int -> int -> int
 end
 
 module Pipe: functor(RW: RW) -> S

--- a/lib_test/jbuild
+++ b/lib_test/jbuild
@@ -1,11 +1,13 @@
 (library
  ((name test_library)
   (c_names (old_ring_stubs))
+  (modules ())
 ))
 
 (executables
  ((names     (ring_test))
   (libraries (lwt lwt.unix shared-memory-ring oUnit test_library))
+  (preprocess (pps (cstruct.ppx)))
 ))
 
 (alias


### PR DESCRIPTION
The `read` API must now take a `bytes` value rathe than `string` to build on OCaml 4.06 which has `-safe-string` enabled by default.

This is an API change, so prepare to release 3.0.0.