### PR TITLE
Add Ring.Rpc.of_buf_no_init

### DIFF
--- a/lib/ring.ml
+++ b/lib/ring.ml
@@ -76,8 +76,7 @@ module Rpc = struct
     name: string;     (* For pretty printing only *)
   }
 
-  let of_buf ~buf ~idx_size ~name =
-    initialise buf;
+  let of_buf_no_init ~buf ~idx_size ~name =
     let header_size = 4+4+4+4+48 in (* header bytes size of struct sring *)
     (* Round down to the nearest power of 2, so we can mask indices easily *)
     let round_down_to_nearest_2 x =
@@ -86,6 +85,10 @@ module Rpc = struct
     let free_bytes = length buf - header_size in
     let nr_ents = round_down_to_nearest_2 (free_bytes / idx_size) in
     { name; buf; idx_size; nr_ents; header_size }
+
+  let of_buf ~buf ~idx_size ~name =
+    initialise buf;
+    of_buf_no_init ~buf ~idx_size ~name
 
   let to_summary_string t =
     Printf.sprintf "ring %s header_size = %d; index slot size = %d; number of entries = %d" t.name t.header_size t.idx_size t.nr_ents

--- a/lib/ring.mli
+++ b/lib/ring.mli
@@ -30,6 +30,10 @@ module Rpc : sig
       pretty-printing. [buf] should be a Cstruct.t comprising pre-allocated
       contiguous I/O pages. *)
 
+  val of_buf_no_init : buf:Cstruct.t -> idx_size:int -> name:string -> sring
+  (** [of_buf_no_init] is like [of_buf], but does not initialise the ring.
+      Use this if the other party has already initialised it. *)
+
   val to_summary_string : sring -> string
   (** [to_summary_string ring] is a printable single-line summary of the
       ring. *)


### PR DESCRIPTION
It seems that the only way to get an `Rpc.sring` was to use `of_buf`, which also initialises the ring. This is a problem if the other party has already initialised it, as it overwrites their data.

In particular, this prevented Qubes disposable Linux VMs from working when restored. They would populate the ring with RX pages before handing it to the Mirage netback, which would then reinitialise the ring and lose them all. It would then wait forever for Linux to provide it with some pages to write to.

At least, this is my guess. The protocol does not appear to be documented anywhere.