### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/shared-memory-ring-lwt.opam
+++ b/shared-memory-ring-lwt.opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/shared-memory-ring/"
 bug-reports: "https://github.com/mirage/shared-memory-ring/issues"
 depends: [
   "ocaml" {>= "4.02.0"}
-  "dune" {build}
+  "dune"
   "cstruct" {>= "2.4.1"}
   "ppx_cstruct"
   "shared-memory-ring"

--- a/shared-memory-ring.opam
+++ b/shared-memory-ring.opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/shared-memory-ring/"
 bug-reports: "https://github.com/mirage/shared-memory-ring/issues"
 depends: [
   "ocaml" {>= "4.02.0"}
-  "dune" {build}
+  "dune"
   "cstruct" {>= "2.4.1"}
   "ppx_cstruct" {>= "3.2.0"}
   "mirage-profile"


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.