### PR TITLE
Fix example client

### DIFF
--- a/examples/client.ml
+++ b/examples/client.ml
@@ -14,65 +14,50 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-(*
-open Lwt
-
 let ( |> ) a b = b a
 let id x = x
-
-let alloc_page () =
-	Bigarray.Array1.create Bigarray.char Bigarray.c_layout 4096
+let alloc_page () = Bigarray.Array1.create Bigarray.char Bigarray.c_layout 4096
 
 let one_request_response () =
-	let page = alloc_page () in
-	let sring = Ring.Rpc.of_buf ~buf:(Cstruct.of_bigarray page) ~idx_size:1 ~name:"test" in
-	let front = Ring.Rpc.Front.init sring in
-	let back = Ring.Rpc.Back.init sring in
+  let page = alloc_page () in
+  let sring =
+    Ring.Rpc.of_buf ~buf:(Cstruct.of_bigarray page) ~idx_size:1 ~name:"test"
+  in
+  let front = Ring.Rpc.Front.init ~sring in
+  let back = Ring.Rpc.Back.init ~sring in
 
-	Printf.fprintf stdout "%s\n%!" (Ring.Rpc.Back.to_string back);
-	assert_equal ~msg:"more_to_do" ~printer:string_of_bool false (Ring.Rpc.Back.more_to_do back);
+  Printf.fprintf stdout "%s\n%!" (Ring.Rpc.Back.to_string back);
 
-	let client = Lwt_ring.Front.init front in
-	let server = Lwt_ring.Back.init back in
+  let client = Lwt_ring.Front.init string_of_int front in
+  let server = Lwt_ring.Back.init string_of_int back in
 
-	let id = () in
-	let must_notify = ref false in
-	let request_th = Lwt_ring.Front.push_request_and_wait client (fun () -> must_notify := true) (fun _ -> id) in
-	assert_equal ~msg:"must_notify" ~printer:string_of_bool true (!must_notify);
-	Printf.fprintf stdout "%s\n%!" (Ring.Rpc.Back.to_string back);
-	assert_equal ~msg:"more_to_do" ~printer:string_of_bool true (Ring.Rpc.Back.more_to_do back);
+  let id = 0 in
+  let must_notify = ref false in
+  let request_th =
+    Lwt_ring.Front.push_request_and_wait client
+      (fun () -> must_notify := true)
+      (fun _ -> id)
+  in
+  assert !must_notify;
+  Printf.fprintf stdout "%s\n%!" (Ring.Rpc.Back.to_string back);
 
-	let finished = ref false in
-	Ring.Rpc.Back.ack_requests back (fun _ -> finished := true);
-	assert_equal ~msg:"ack_requests" ~printer:string_of_bool true (!finished);
+  let finished = ref false in
+  Ring.Rpc.Back.ack_requests back (fun _ -> finished := true);
 
-	Lwt_ring.Back.push_response server (fun () -> ()) (fun _ -> ());
+  assert !finished;
+  Lwt_ring.Back.push_response server (fun () -> ()) (fun _ -> ());
 
-	Printf.fprintf stdout "%s\n%!" (Ring.Rpc.Back.to_string back);
+  Printf.fprintf stdout "%s\n%!" (Ring.Rpc.Back.to_string back);
 
-    let replied = ref false in
-	Lwt_ring.Front.poll client (fun _ -> replied := true; id, ());
-	assert_equal ~msg:"poll" ~printer:string_of_bool true (!replied);
+  let replied = ref false in
+  Lwt_ring.Front.poll client (fun _ ->
+      replied := true;
+      (id, ()));
 
-	assert_equal ~msg:"more_to_do" ~printer:string_of_bool false (Ring.Rpc.Back.more_to_do back);
-	lwt () = Lwt.choose [ Lwt_unix.sleep 5.; request_th ] in
-	assert_equal ~msg:"is_sleeping" ~printer:string_of_bool false (Lwt.is_sleeping request_th);
-	return ()
+  assert !replied;
 
-let one_request_response () = Lwt_main.run (one_request_response ())
+  let p = Lwt.choose [ Lwt_unix.sleep 5.; request_th ] in
+  assert (not @@ Lwt.is_sleeping request_th);
+  p
 
-let _ =
-  let verbose = ref false in
-  Arg.parse [
-    "-verbose", Arg.Unit (fun _ -> verbose := true), "Run in verbose mode";
-  ] (fun x -> Printf.fprintf stderr "Ignoring argument: %s" x)
-    "Test shared memory ring code";
-
-  let suite = "ring" >:::
-    [
-		"one_request_response" >:: one_request_response
-    ] in
-  run_test_tt ~verbose:!verbose suite
-*)
-
-let () = print_string "hello\n"
+let () = Lwt_main.run (one_request_response ())

--- a/shared-memory-ring.opam
+++ b/shared-memory-ring.opam
@@ -11,7 +11,6 @@ depends: [
   "dune"
   "cstruct" {>= "6.0.0"}
   "ppx_cstruct" {>= "3.2.0"}
-  "mirage-profile"
   "ounit" {with-test}
 ]
 build: [


### PR DESCRIPTION
Two minor fixes:

- Remove `mirage-profile` as dependency of the `shared-memory-ring` OPAM file
- Uncomment and fix the `client.ml` example